### PR TITLE
Fix hitbox size not matching object's texture

### DIFF
--- a/main.py
+++ b/main.py
@@ -116,6 +116,9 @@ class GrowingAnimation(Animation):
                 self.player.SNAKE_HEAD_IMAGE,
                 new_snake_size,
             )
+            self.player.hitbox = Hitbox(
+                *new_snake_size, self.player.x[0], self.player.y[0]
+            )
         else:
             if self.counter == 4:
                 self.counter = 0
@@ -361,7 +364,9 @@ class App:
                 ),
                 size=size,
             )
-            for _, size in zip(self.food_images, self.food_sizes)
+            for _, size in zip(
+                self.food_images, self.food_sizes
+            )  # ? why is food_images zipped but is never used?
         ]
 
     def game_over(self):
@@ -418,7 +423,6 @@ class App:
         pygame.mixer.Channel(0).play(self.game.background_music, loops=-1)
         pygame.mixer.Channel(0).set_volume(0.01)
         while True:
-            print(self.player.hitbox)
             events = pygame.event.get()
             for event in events:
                 if event.type == QUIT:
@@ -445,6 +449,7 @@ class App:
                             self.border.top_left, self.border.bottom_right
                         )
                     )
+                    food.hitbox = Hitbox(*food.size, food.x, food.y)
                 self.player.animation.reset_food = False
 
             # test if eating food 🍔
@@ -528,7 +533,10 @@ class App:
 
                 pygame.mixer.Channel(1).play(self.game.grow_sound)
                 self.player.animation.playing = True
-            print(self.food)
+                for food in self.food:
+                    print(food.hitbox, food.size)
+                    food.hitbox = Hitbox(*food.size, food.x, food.y)
+                    print(food.hitbox, food.size)
             self.tick()
 
 


### PR DESCRIPTION
Fixed issue #3 

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Hitbox size not matching their texture

Issue Number: #3 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- On food scale down, its hitbox will scale down too.
- When a player grows in size/shrinks, their hitbox grows/shrinks too.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- ## Other information -->

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
